### PR TITLE
added a failing unit test for ODataFilterBuilder, testing mixed types

### DIFF
--- a/src/CSESoftware.OData.Tests/FilterBuilderTests.cs
+++ b/src/CSESoftware.OData.Tests/FilterBuilderTests.cs
@@ -9,6 +9,17 @@ namespace CSESoftware.OData.Tests
     public class FilterBuilderTests
     {
         [TestMethod]
+        public void WithMixedObjectTypes()
+        {
+            var filter = new ODataFilterBuilder<Timesheet>()
+                .Where(x => x.Comment, Operation.Contains, "great")
+                .AndWhere(x => x.EmployeeId, Operation.Equals, 1)
+                .BuildObject();
+
+            Assert.AreEqual("(contains(Comment, 'great') and (EmployeeId) eq 1)", filter.Filter);
+        }
+
+        [TestMethod]
         public void WithIdBuildTest()
         {
             var filter = new ODataFilterBuilder<Timesheet>()


### PR DESCRIPTION
added a failing unit test for ODataFilterBuilder. The test checks validity for filter builder when Where() and AndWhere() are used with mixed data types (first method supplied with string, second one with int). This produces an invalid parenthesis nesting.