### PR TITLE
Correctly shift all single quotes to double quotes

### DIFF
--- a/src/CSESoftware.OData.Tests/Helpers/Employee.cs
+++ b/src/CSESoftware.OData.Tests/Helpers/Employee.cs
@@ -5,5 +5,6 @@ namespace CSESoftware.OData.Tests.Helpers
     public class Employee : BaseEntity<int>
     {
         public string Name { get; set; }
+        public string Address { get; set; }
     }
 }

--- a/src/CSESoftware.OData.Tests/StringConverterTests.cs
+++ b/src/CSESoftware.OData.Tests/StringConverterTests.cs
@@ -131,5 +131,13 @@ namespace CSESoftware.OData.Tests
             var expression = GenerateExpressionFilter<Employee>(filter);
             Assert.AreEqual("(entity.Name == \"Bob\")", expression.Body.ToString());
         }
+
+        [TestMethod]
+        public void TwoStringExpressionsTest()
+        {
+            var filter = "Name eq 'Bob' and Address eq 'Boo'";
+            var expression = GenerateExpressionFilter<Employee>(filter);
+            Assert.AreEqual("((entity.Name == \"Bob\") AndAlso (entity.Address == \"Boo\"))", expression.Body.ToString());
+        }
     }
 }

--- a/src/CSESoftware.OData/CSESoftware.OData.csproj
+++ b/src/CSESoftware.OData/CSESoftware.OData.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <Authors>CSE Software, Inc.</Authors>
     <Copyright>2022 CSE Software, Inc.</Copyright>
     <Description>Library to convert Open Data REST API queries into queries for CSESoftware.Repository.</Description>

--- a/src/CSESoftware.OData/ODataRepository.cs
+++ b/src/CSESoftware.OData/ODataRepository.cs
@@ -156,6 +156,7 @@ namespace CSESoftware.OData
         {
             filter = filter.Replace("\"", "\\\"");
             filter = filter.Replace(" '", " \"");
+            filter = filter.Replace("' ", "\" ");
             filter = filter.Replace(",'", ",\"");
             filter = filter.Replace("('", "(\"");
             filter = filter.Replace("')", "\")");


### PR DESCRIPTION
Bugfix for two string properties in the filter expression; one single quote was missing conversion, resulting in syntax error.